### PR TITLE
优化高亮行及右键菜单的交互

### DIFF
--- a/packages/keyboard/src/mixin.js
+++ b/packages/keyboard/src/mixin.js
@@ -185,7 +185,7 @@ export default {
           }
         }
       }
-      this.scrollToRow(params.row, params.column).then(() => {
+      this.scrollToRow(params.row, params.column).then(() => this.triggerCurrentRowEvent(evnt, params)).then(() => {
         params.cell = DomTools.getCell(this, params)
         this.handleSelected(params, evnt)
       })

--- a/packages/table/src/methods.js
+++ b/packages/table/src/methods.js
@@ -1751,7 +1751,7 @@ const Methods = {
           // 如果按下了方向键
           if (selected.row && selected.column) {
             this.moveSelected(selected.args, isLeftArrow, isUpArrow, isRightArrow, isDwArrow, evnt)
-          } else if ((isUpArrow || isDwArrow) && highlightCurrentRow && currentRow) {
+          } else if ((isUpArrow || isDwArrow) && !actived.row && highlightCurrentRow && currentRow) {
             // 当前行按键上下移动
             this.moveCurrentRow(isUpArrow, isDwArrow, evnt)
           }


### PR DESCRIPTION
1. 使用键盘的context键可以在表格的行或者单元格上触发右键菜单(原来不能)
2.
修复了在选中单元格进行编辑时同时有高亮行显示的时候，使用上下键导致高亮行移动的问题
3. 修复了使用右键单击表格不会触发高亮行的问题