### PR TITLE
props expandConfig 属性值类型问题

### DIFF
--- a/packages/table/src/table.js
+++ b/packages/table/src/table.js
@@ -180,7 +180,7 @@ export default {
     // 打印配置项
     printConfig: Object,
     // 展开行配置项
-    expandConfig: Object,
+    expandConfig: [Boolean, Object],
     // 树形结构配置项
     treeConfig: [Boolean, Object],
     // 快捷菜单配置项


### PR DESCRIPTION
  expandConfig开启对性能有极大影响，expand木有直接提供关闭功能，应当增加Boolean类型急相关处理来支持关闭此项功能，此类的配置应当都支持[Boolean, Object]，以此来开启或配置其他功能，支持基于vxe-table的二次封装。
  expandConfig: [Boolean, Object],