### PR TITLE
修复 column colgroup 类型定义文件位置互换的问题

### DIFF
--- a/packages/colgroup/index.d.ts
+++ b/packages/colgroup/index.d.ts
@@ -1,4 +1,4 @@
-import { Column } from '../../types/column'
+import { Colgroup } from '../../types/colgroup'
 
-export * from '../../types/column'
-export default Column
+export * from '../../types/colgroup'
+export default Colgroup

--- a/packages/column/index.d.ts
+++ b/packages/column/index.d.ts
@@ -1,4 +1,4 @@
-import { Colgroup } from '../../types/colgroup'
+import { Column } from '../../types/column'
 
-export * from '../../types/colgroup'
-export default Colgroup
+export * from '../../types/column'
+export default Column


### PR DESCRIPTION
这两个文件放反了