### PR TITLE
fix: column width number 0 invalid

### DIFF
--- a/packages/table/src/methods.js
+++ b/packages/table/src/methods.js
@@ -1457,10 +1457,10 @@ const Methods = {
     const scaleMinList = []
     const autoList = []
     this.tableFullColumn.forEach(column => {
-      if (defaultWidth && !column.width) {
+      if (defaultWidth && XEUtils.eqNull(column.width)) {
         column.width = defaultWidth
       }
-      if (defaultMinWidth && !column.minWidth) {
+      if (defaultMinWidth && XEUtils.eqNull(column.minWidth)) {
         column.minWidth = defaultMinWidth
       }
       if (column.visible) {

--- a/packages/tools/src/dom.js
+++ b/packages/tools/src/dom.js
@@ -83,7 +83,7 @@ export function setScrollLeft (elem, scrollLeft) {
 export const DomTools = {
   browse,
   isPx (val) {
-    return val && /^\d+(px)?$/.test(val)
+    return !XEUtils.eqNull(val) && /^\d+(px)?$/.test(val)
   },
   isScale,
   hasClass,


### PR DESCRIPTION
修复column width使用数字 `0` 时无效的问题，当前只能使用字符串 `'0'` 来设置零宽度。