### PR TITLE
增加定制表格表头单元格行数功能：

### DIFF
--- a/examples/views/grid/Group.vue
+++ b/examples/views/grid/Group.vue
@@ -10,6 +10,17 @@
       <pre-code class="xml">{{ demoCodes[0] }}</pre-code>
       <pre-code class="typescript">{{ demoCodes[1] }}</pre-code>
     </pre>
+
+    <p class="tip">定制表头单元格所占的行</p>
+    <vxe-grid v-bind="gridOptions2"></vxe-grid>
+
+    <p class="demo-code">{{ $t('app.body.button.showCode') }}</p>
+
+    <pre>
+      <pre-code class="xml">{{ demoCodes[2] }}</pre-code>
+      <pre-code class="typescript">{{ demoCodes[3] }}</pre-code>
+    </pre>
+
   </div>
 </template>
 
@@ -53,9 +64,49 @@ export default defineComponent({
         { id: 10008, name: 'Test8', nickname: 'T8', role: 'Develop', sex: 'Man', age: 35, address: 'Shenzhen' }
       ]
     })
-
+    const gridOptions2 = reactive<VxeGridProps>({
+      border: true,
+      stripe: true,
+      resizable: true,
+      useCustomHeaderRowSpan: true,
+      height: 500,
+      columns: [
+        {
+          title: '序号',
+          customRowSpan: 3,
+          fixed: 'left',
+          children: [{ type: 'seq', title: '1' }]
+        },
+        {
+          title: '基本信息',
+          children: [
+            { title: 'Name', customRowSpan: 2, children: [{ field: 'name', title: '2' }] },
+            {
+              title: '其他信息',
+              children: [
+                { title: 'Nickname', children: [{ field: 'nickname', title: '3' }] },
+                { title: 'Age', children: [{ field: 'age', title: '4' }] }
+              ]
+            },
+            { title: 'Sex', customRowSpan: 2, children: [{ field: 'sex', title: '5' }] }
+          ]
+        },
+        { title: 'Address', customRowSpan: 3, children: [{ field: 'address', title: '6', showOverflow: true }] }
+      ],
+      data: [
+        { id: 10001, name: 'Test1', nickname: 'T1', role: 'Develop', sex: 'Man', age: 28, address: 'Shenzhen' },
+        { id: 10002, name: 'Test2', nickname: 'T2', role: 'Test', sex: 'Women', age: 22, address: 'Guangzhou' },
+        { id: 10003, name: 'Test3', nickname: 'T3', role: 'PM', sex: 'Man', age: 32, address: 'Shanghai' },
+        { id: 10004, name: 'Test4', nickname: 'T4', role: 'Designer', sex: 'Women', age: 23, address: 'Shenzhen' },
+        { id: 10005, name: 'Test5', nickname: 'T5', role: 'Develop', sex: 'Women', age: 30, address: 'Shanghai' },
+        { id: 10006, name: 'Test6', nickname: 'T6', role: 'Designer', sex: 'Women', age: 21, address: 'Shenzhen' },
+        { id: 10007, name: 'Test7', nickname: 'T7', role: 'Test', sex: 'Man', age: 29, address: 'Shenzhen' },
+        { id: 10008, name: 'Test8', nickname: 'T8', role: 'Develop', sex: 'Man', age: 35, address: 'Shenzhen' }
+      ]
+    })
     return {
       gridOptions,
+      gridOptions2,
       demoCodes: [
         `
         <vxe-grid v-bind="gridOptions"></vxe-grid>
@@ -88,6 +139,62 @@ export default defineComponent({
                   ]
                 },
                 { field: 'address', title: 'Address', sortable: true, showOverflow: true }
+              ],
+              data: [
+                { id: 10001, name: 'Test1', nickname: 'T1', role: 'Develop', sex: 'Man', age: 28, address: 'Shenzhen' },
+                { id: 10002, name: 'Test2', nickname: 'T2', role: 'Test', sex: 'Women', age: 22, address: 'Guangzhou' },
+                { id: 10003, name: 'Test3', nickname: 'T3', role: 'PM', sex: 'Man', age: 32, address: 'Shanghai' },
+                { id: 10004, name: 'Test4', nickname: 'T4', role: 'Designer', sex: 'Women', age: 23, address: 'Shenzhen' },
+                { id: 10005, name: 'Test5', nickname: 'T5', role: 'Develop', sex: 'Women', age: 30, address: 'Shanghai' },
+                { id: 10006, name: 'Test6', nickname: 'T6', role: 'Designer', sex: 'Women', age: 21, address: 'Shenzhen' },
+                { id: 10007, name: 'Test7', nickname: 'T7', role: 'Test', sex: 'Man', age: 29, address: 'Shenzhen' },
+                { id: 10008, name: 'Test8', nickname: 'T8', role: 'Develop', sex: 'Man', age: 35, address: 'Shenzhen' }
+              ]
+            })
+
+            return {
+              gridOptions
+            }
+          }
+        })
+        `,
+        `
+        <vxe-grid v-bind="gridOptions"></vxe-grid>
+        `,
+        `
+        import { defineComponent, reactive } from 'vue'
+        import { VxeGridProps } from 'vxe-table'
+
+        export default defineComponent({
+          setup () {
+            const gridOptions = reactive<VxeGridProps>({
+              border: true,
+              stripe: true,
+              resizable: true,
+              useCustomHeaderRowSpan: true,
+              height: 500,
+              columns: [
+                {
+                  title: '序号',
+                  customRowSpan: 3,
+                  fixed: 'left',
+                  children: [{ type: 'seq', title: '1' }]
+                },
+                {
+                  title: '基本信息',
+                  children: [
+                    { title: 'Name', customRowSpan: 2, children: [{ field: 'name', title: '2' }] },
+                    {
+                      title: '其他信息',
+                      children: [
+                        { title: 'Nickname', children: [{ field: 'nickname', title: '3' }] },
+                        { title: 'Age', children: [{ field: 'age', title: '4' }] }
+                      ]
+                    },
+                    { title: 'Sex', customRowSpan: 2, children: [{ field: 'sex', title: '5' }] }
+                  ]
+                },
+                { title: 'Address', customRowSpan: 3, children: [{ field: 'address', title: '6', showOverflow: true }] }
               ],
               data: [
                 { id: 10001, name: 'Test1', nickname: 'T1', role: 'Develop', sex: 'Man', age: 28, address: 'Shenzhen' },

--- a/examples/views/table/base/Group.vue
+++ b/examples/views/table/base/Group.vue
@@ -1,5 +1,6 @@
 <template>
   <div>
+
     <p class="tip">当数据结构比较复杂的时候，可以使用多级表头来更加直观的显示数据</p>
 
     <vxe-table
@@ -76,6 +77,76 @@
       <pre-code class="xml">{{ demoCodes[2] }}</pre-code>
       <pre-code class="typescript">{{ demoCodes[3] }}</pre-code>
     </pre>
+
+    <hr>
+
+    <p class="tip">定制表头单元格所占的行</p>
+
+    <vxe-toolbar>
+      <template #buttons>
+        <vxe-button @click="toggleFixedColumn3('group0', 'left')">切换第一列固定</vxe-button>
+        <vxe-button @click="toggleFixedColumn3('group1', 'left')">切换第二列固定</vxe-button>
+        <vxe-button @click="toggleFixedColumn3('group3', 'right')">切换第四列固定</vxe-button>
+        <vxe-button @click="toggleFixedColumn3('group4', 'right')">切换第五列固定</vxe-button>
+      </template>
+    </vxe-toolbar>
+
+    <vxe-table
+      border
+      ref="xTable3"
+      height="400"
+      useCustomHeaderRowSpan=true
+      :data="tableData3">
+      <vxe-colgroup title="基本信息" customRowSpan="2">
+        <vxe-colgroup title="序号">
+          <vxe-column type="seq" title="1" width="60"></vxe-column>
+        </vxe-colgroup>
+        <vxe-colgroup title="姓名">
+          <vxe-column field="name" title="2" width="80"></vxe-column>
+        </vxe-colgroup>
+      </vxe-colgroup>
+      <vxe-colgroup title="分类信息1" customRowSpan="2">
+        <vxe-colgroup title="年龄">
+          <vxe-column field="age" title="3" width="100"></vxe-column>
+        </vxe-colgroup>
+      </vxe-colgroup>
+      <vxe-colgroup title="更多信息">
+        <vxe-colgroup title="角色"  customRowSpan="2">
+          <vxe-column field="role" title="4" width="60"></vxe-column>
+        </vxe-colgroup>
+        <vxe-colgroup title="Attr1"  customRowSpan="2">
+          <vxe-column field="attr1" title="5" width="60"></vxe-column>
+        </vxe-colgroup>
+        <vxe-colgroup title="详细信息">
+          <vxe-colgroup title="Sex" >
+            <vxe-column field="sex" title="6" width="60"></vxe-column>
+          </vxe-colgroup>
+          <vxe-colgroup title="Num">
+          <vxe-column field="num" title="7" width="60"></vxe-column>
+          </vxe-colgroup>
+        </vxe-colgroup>
+      </vxe-colgroup>
+      <vxe-colgroup title="分类信息2"  customRowSpan="2">
+        <vxe-colgroup title="Attr6">
+          <vxe-column field="attr6" title="8" width="120"></vxe-column>
+        </vxe-colgroup>
+      </vxe-colgroup>
+      <vxe-colgroup title="额外信息"  customRowSpan="2">
+        <vxe-colgroup title="Date">
+          <vxe-column field="date3" title="9" width="140"></vxe-column>
+        </vxe-colgroup>
+        <vxe-colgroup title="Address">
+          <vxe-column field="address" title="10" width="200" show-overflow></vxe-column>
+        </vxe-colgroup>
+      </vxe-colgroup>
+    </vxe-table>
+
+    <p class="demo-code">{{ $t('app.body.button.showCode') }}</p>
+
+    <pre>
+      <pre-code class="xml">{{ demoCodes[4] }}</pre-code>
+      <pre-code class="typescript">{{ demoCodes[5] }}</pre-code>
+    </pre>
   </div>
 </template>
 
@@ -123,11 +194,39 @@ export default defineComponent({
       }
     }
 
+    const xTable3 = ref({} as VxeTableInstance)
+    const tableData3 = ref([
+      { id: 10001, name: 'Test1', role: 'Develop', sex: 'Man', age: 28, address: 'test abc' },
+      { id: 10002, name: 'Test2', role: 'Test', sex: 'Women', age: 22, address: 'Guangzhou' },
+      { id: 10003, name: 'Test3', role: 'PM', sex: 'Man', age: 32, address: 'Shanghai' },
+      { id: 10004, name: 'Test4', role: 'Designer', sex: 'Women', age: 23, address: 'test abc' },
+      { id: 10005, name: 'Test5', role: 'Develop', sex: 'Women', age: 30, address: 'Shanghai' },
+      { id: 10006, name: 'Test6', role: 'Designer', sex: 'Women', age: 21, address: 'test abc' },
+      { id: 10007, name: 'Test7', role: 'Test', sex: 'Man', age: 29, address: 'test abc' },
+      { id: 10008, name: 'Test8', role: 'Develop', sex: 'Man', age: 35, address: 'test abc' }
+    ])
+
+    const toggleFixedColumn3 = (field: string, type: VxeColumnPropTypes.Fixed) => {
+      const $table = xTable3.value
+      const column = $table.getColumnByField(field)
+      if (column) {
+        const groupFixed = column.fixed ? null : type
+        // 将分组整体设置固定列
+        XEUtils.eachTree([column], column => {
+          column.fixed = groupFixed
+        })
+        // 刷新列
+        $table.refreshColumn()
+      }
+    }
     return {
       tableData1,
       xTable2,
       tableData2,
       toggleFixedColumn,
+      xTable3,
+      tableData3,
+      toggleFixedColumn3,
       demoCodes: [
         `
         <vxe-table
@@ -250,6 +349,108 @@ export default defineComponent({
               xTable2,
               tableData2,
               toggleFixedColumn
+            }
+          }
+        }
+        `,
+        `
+        <vxe-toolbar>
+          <template #buttons>
+            <vxe-button @click="toggleFixedColumn3('group0', 'left')">切换第一列固定</vxe-button>
+            <vxe-button @click="toggleFixedColumn3('group1', 'left')">切换第二列固定</vxe-button>
+            <vxe-button @click="toggleFixedColumn3('group3', 'right')">切换第四列固定</vxe-button>
+            <vxe-button @click="toggleFixedColumn3('group4', 'right')">切换第五列固定</vxe-button>
+          </template>
+        </vxe-toolbar>
+
+        <vxe-table
+          border
+          ref="xTable3"
+          height="400"
+          useCustomHeaderRowSpan=true
+          :data="tableData3">
+          <vxe-colgroup title="基本信息" customRowSpan="2">
+            <vxe-colgroup title="序号">
+              <vxe-column type="seq" title="1" width="60"></vxe-column>
+            </vxe-colgroup>
+            <vxe-colgroup title="姓名">
+              <vxe-column field="name" title="2" width="80"></vxe-column>
+            </vxe-colgroup>
+          </vxe-colgroup>
+          <vxe-colgroup title="分类信息1" customRowSpan="2">
+            <vxe-colgroup title="年龄">
+              <vxe-column field="age" title="3" width="100"></vxe-column>
+            </vxe-colgroup>
+          </vxe-colgroup>
+          <vxe-colgroup title="更多信息">
+            <vxe-colgroup title="角色"  customRowSpan="2">
+              <vxe-column field="role" title="4" width="60"></vxe-column>
+            </vxe-colgroup>
+            <vxe-colgroup title="Attr1"  customRowSpan="2">
+              <vxe-column field="attr1" title="5" width="60"></vxe-column>
+            </vxe-colgroup>
+            <vxe-colgroup title="详细信息">
+              <vxe-colgroup title="Sex" >
+                <vxe-column field="sex" title="6" width="60"></vxe-column>
+              </vxe-colgroup>
+              <vxe-colgroup title="Num">
+              <vxe-column field="num" title="7" width="60"></vxe-column>
+              </vxe-colgroup>
+            </vxe-colgroup>
+          </vxe-colgroup>
+          <vxe-colgroup title="分类信息2"  customRowSpan="2">
+            <vxe-colgroup title="Attr6">
+              <vxe-column field="attr6" title="8" width="120"></vxe-column>
+            </vxe-colgroup>
+          </vxe-colgroup>
+          <vxe-colgroup title="额外信息"  customRowSpan="2">
+            <vxe-colgroup title="Date">
+              <vxe-column field="date3" title="9" width="140"></vxe-column>
+            </vxe-colgroup>
+            <vxe-colgroup title="Address">
+              <vxe-column field="address" title="10" width="200" show-overflow></vxe-column>
+            </vxe-colgroup>
+          </vxe-colgroup>
+        </vxe-table>
+        `,
+        `
+        import { defineComponent, ref } from 'vue'
+        import { VxeTableInstance, VxeColumnPropTypes } from 'vxe-table'
+        import XEUtils from 'xe-utils'
+
+        export default defineComponent({
+          setup () {
+            const xTable3 = ref({} as VxeTableInstance)
+
+            const tableData3 = ref([
+              { id: 10001, name: 'Test1', role: 'Develop', sex: 'Man', age: 28, address: 'test abc' },
+              { id: 10002, name: 'Test2', role: 'Test', sex: 'Women', age: 22, address: 'Guangzhou' },
+              { id: 10003, name: 'Test3', role: 'PM', sex: 'Man', age: 32, address: 'Shanghai' },
+              { id: 10004, name: 'Test4', role: 'Designer', sex: 'Women', age: 23, address: 'test abc' },
+              { id: 10005, name: 'Test5', role: 'Develop', sex: 'Women', age: 30, address: 'Shanghai' },
+              { id: 10006, name: 'Test6', role: 'Designer', sex: 'Women', age: 21, address: 'test abc' },
+              { id: 10007, name: 'Test7', role: 'Test', sex: 'Man', age: 29, address: 'test abc' },
+              { id: 10008, name: 'Test8', role: 'Develop', sex: 'Man', age: 35, address: 'test abc' }
+            ])
+
+            const toggleFixedColumn3 = (field: string, type: VxeColumnPropTypes.Fixed) => {
+              const $table = xTable3.value
+              const column = $table.getColumnByField(field)
+              if (column) {
+                const groupFixed = column.fixed ? null : type
+                // 将分组整体设置固定列
+                XEUtils.eachTree([column], column => {
+                  column.fixed = groupFixed
+                })
+                // 刷新列
+                $table.refreshColumn()
+              }
+            }
+
+            return {
+              xTable3,
+              tableData3,
+              toggleFixedColumn3
             }
           }
         }

--- a/packages/header/src/header.ts
+++ b/packages/header/src/header.ts
@@ -15,7 +15,8 @@ export default defineComponent({
     tableColumn: Array as PropType<VxeTableDefines.ColumnInfo[]>,
     tableGroupColumn: Array as PropType<VxeTableDefines.ColumnInfo[]>,
     fixedColumn: Array as PropType<VxeTableDefines.ColumnInfo[]>,
-    fixedType: { type: String as PropType<VxeColumnPropTypes.Fixed>, default: null }
+    fixedType: { type: String as PropType<VxeColumnPropTypes.Fixed>, default: null },
+    useCustomHeaderRowSpan: { type: Boolean, default: false }
   },
   setup (props) {
     const $xetable = inject('$xetable', {} as VxeTableConstructor & VxeTableMethods & VxeTablePrivateMethods)
@@ -35,7 +36,7 @@ export default defineComponent({
 
     const uploadColumn = () => {
       const { isGroup } = tableReactData
-      headerColumn.value = isGroup ? convertToRows(props.tableGroupColumn) : []
+      headerColumn.value = isGroup ? convertToRows(props.tableGroupColumn, props.useCustomHeaderRowSpan) : []
     }
 
     const resizeMousedown = (evnt: MouseEvent, params: any) => {

--- a/packages/header/src/util.ts
+++ b/packages/header/src/util.ts
@@ -14,7 +14,7 @@ const getAllColumns = (columns: any, parentColumn?: any) => {
   return result
 }
 
-export const convertToRows = (originColumns: any): any[][] => {
+export const convertToRows = (originColumns: any, useCustomRowSpan?: boolean): any[][] => {
   let maxLevel = 1
   const traverse = (column: any, parent?: any) => {
     if (parent) {
@@ -49,13 +49,48 @@ export const convertToRows = (originColumns: any): any[][] => {
 
   const allColumns = getAllColumns(originColumns)
 
-  allColumns.forEach((column) => {
-    if (column.children && column.children.length && column.children.some((column: any) => column.visible)) {
-      column.rowSpan = 1
-    } else {
-      column.rowSpan = maxLevel - column.level + 1
+  // rowSpan 计算
+  const getGroupParentRowSpan = (columnId: string) => {
+    let r = 0
+    for (let i = 0; i < allColumns.length; i++) {
+      const column = allColumns[i]
+      if (column.id === columnId) {
+        if (column.rowSpan && column.rowSpan > 1) {
+          r = r + column.rowSpan
+        }
+        if (column.parentId) {
+          r = r + getGroupParentRowSpan(column.parentId)
+        }
+      }
     }
-    rows[column.level - 1].push(column)
+    return r
+  }
+
+  allColumns.forEach((column) => {
+    if (useCustomRowSpan) {
+      if (column.customRowSpan) {
+        column.rowSpan = column.customRowSpan
+      } else {
+        column.rowSpan = 1
+      }
+      let alevel = column.level - 1
+      if (column.parentId) {
+        let parentRowSpan = getGroupParentRowSpan(column.parentId)
+        parentRowSpan = parentRowSpan > 0 ? parentRowSpan - 1 : 0
+        alevel = alevel + parentRowSpan
+        if (alevel >= maxLevel) {
+          alevel = maxLevel - 1
+        }
+      }
+      rows[alevel].push(column)
+    } else {
+      if (column.children && column.children.length && column.children.some((column: any) => column.visible)) {
+        column.rowSpan = 1
+      } else {
+        column.rowSpan = maxLevel - column.level + 1
+      }
+      rows[column.level - 1].push(column)
+    }
   })
 
   return rows

--- a/packages/table/src/column.ts
+++ b/packages/table/src/column.ts
@@ -27,6 +27,8 @@ export const columnProps = {
   headerAlign: String as PropType<VxeColumnPropTypes.HeaderAlign>,
   // 表尾列的对齐方式
   footerAlign: String as PropType<VxeColumnPropTypes.FooterAlign>,
+  // 定制行高
+  customRowSpan: { type: [Number, String] as PropType<VxeColumnPropTypes.CustomRowSpan>, default: 1 },
   // 当内容过长时显示为省略号
   showOverflow: { type: [Boolean, String] as PropType<VxeColumnPropTypes.ShowOverflow>, default: null },
   // 当表头内容过长时显示为省略号

--- a/packages/table/src/columnInfo.ts
+++ b/packages/table/src/columnInfo.ts
@@ -75,6 +75,7 @@ export class ColumnInfo {
       className: _vm.className,
       headerClassName: _vm.headerClassName,
       footerClassName: _vm.footerClassName,
+      customRowSpan: _vm.customRowSpan,
       formatter: formatter,
       sortable: _vm.sortable,
       sortBy: _vm.sortBy,

--- a/packages/table/src/props.ts
+++ b/packages/table/src/props.ts
@@ -160,5 +160,7 @@ export default {
   // （可能会被废弃的参数，不要使用）
   delayHover: { type: Number as PropType<VxeTablePropTypes.DelayHover>, default: () => GlobalConfig.table.delayHover as number },
   // 额外的参数
-  params: Object as PropType<VxeTablePropTypes.Params>
+  params: Object as PropType<VxeTablePropTypes.Params>,
+  // 使用自定义表头单元格行数方式
+  useCustomHeaderRowSpan: { type: Boolean as PropType<VxeTablePropTypes.UseCustomHeaderRowSpan>, default: () => GlobalConfig.table.useCustomHeaderRowSpan }
 }

--- a/packages/table/src/table.ts
+++ b/packages/table/src/table.ts
@@ -63,6 +63,7 @@ export default defineComponent({
       parentHeight: 0,
       // 是否使用分组表头
       isGroup: false,
+      useCustomHeaderRowSpan: false,
       isAllOverflow: false,
       // 复选框属性，是否全选
       isAllSelected: false,
@@ -892,6 +893,7 @@ export default defineComponent({
       const mouseOpts = computeMouseOpts.value
       const isGroup = collectColumn.some(hasChildrenList)
       let isAllOverflow = !!props.showOverflow
+      const useCustomHeaderRowSpan = !!props.useCustomHeaderRowSpan
       let expandColumn: any
       let treeNodeColumn: any
       let checkboxColumn: any
@@ -969,7 +971,7 @@ export default defineComponent({
           errLog('vxe.error.errConflicts', ['mouse-config.area', 'column.type=expand'])
         }
       }
-
+      reactData.useCustomHeaderRowSpan = useCustomHeaderRowSpan
       reactData.isGroup = isGroup
       reactData.treeNodeColumn = treeNodeColumn
       reactData.expandColumn = expandColumn
@@ -5897,7 +5899,7 @@ export default defineComponent({
 
     const renderVN = () => {
       const { loading, stripe, showHeader, height, treeConfig, mouseConfig, showFooter, highlightCell, highlightHoverRow, highlightHoverColumn, editConfig } = props
-      const { isGroup, overflowX, overflowY, scrollXLoad, scrollYLoad, scrollbarHeight, tableData, tableColumn, tableGroupColumn, footerTableData, initStore, columnStore, filterStore } = reactData
+      const { isGroup, useCustomHeaderRowSpan, overflowX, overflowY, scrollXLoad, scrollYLoad, scrollbarHeight, tableData, tableColumn, tableGroupColumn, footerTableData, initStore, columnStore, filterStore } = reactData
       const { leftList, rightList } = columnStore
       const tipConfig = computeTipConfig.value
       const treeOpts = computeTreeOpts.value
@@ -5956,7 +5958,8 @@ export default defineComponent({
               ref: refTableHeader,
               tableData,
               tableColumn,
-              tableGroupColumn
+              tableGroupColumn,
+              useCustomHeaderRowSpan
             }) : createCommentVNode(),
             /**
              * 表体

--- a/types/colgroup.d.ts
+++ b/types/colgroup.d.ts
@@ -65,6 +65,10 @@ export type VxeColgroupProps = {
    */
   visible?: VxeColumnPropTypes.Visible
   /**
+   * 定制行高
+   */
+  customRowSpan?: VxeColumnPropTypes.CustomRowSpan
+  /**
    * 额外的参数
    */
   params?: VxeColumnPropTypes.Params

--- a/types/column.d.ts
+++ b/types/column.d.ts
@@ -23,6 +23,7 @@ export namespace VxeColumnPropTypes {
   export type Align = 'left' | 'center' | 'right' | null
   export type HeaderAlign = Align
   export type FooterAlign = Align
+  export type CustomRowSpan = string | number
   export type ShowOverflow = VxeTablePropTypes.ShowOverflow
   export type ShowHeaderOverflow = ShowOverflow
   export type ShowFooterOverflow = ShowOverflow
@@ -159,7 +160,6 @@ export namespace VxeColumnPropTypes {
   }
 
   export type Params = any
-
   interface FilterSlotParams {
     $panel: VxeFilterPanel
     column: {
@@ -363,5 +363,9 @@ export type VxeColumnProps = {
   /**
    * 额外的参数
    */
-  params?: VxeColumnPropTypes.Params
+  params?: VxeColumnPropTypes.Params,
+  /**
+   * 定制单元格行高
+   */
+  customRowSpan?: VxeColumnPropTypes.CustomRowSpan,
 }

--- a/types/table.d.ts
+++ b/types/table.d.ts
@@ -759,6 +759,8 @@ export interface TableReactData {
   parentHeight: number
   // 是否使用分组表头
   isGroup: boolean
+  // 自定义表头单元格行数
+  useCustomHeaderRowSpan: boolean
   isAllOverflow: boolean
   // 复选框属性，是否全选
   isAllSelected: boolean
@@ -1940,6 +1942,7 @@ export namespace VxeTablePropTypes {
   }
 
   export type Params = any
+  export type UseCustomHeaderRowSpan = boolean
 }
 
 export type VxeTableProps<D = any> = {
@@ -2053,6 +2056,7 @@ export type VxeTableProps<D = any> = {
   scrollX?: VxeTablePropTypes.ScrollX
   scrollY?: VxeTablePropTypes.ScrollY
   params?: VxeTablePropTypes.Params
+  useCustomHeaderRowSpan?: VxeTablePropTypes.UseCustomHeaderRowSpan
 }
 
 export type VxeTableEmits = [


### PR DESCRIPTION
1.通过 useCustomHeaderRowSpan 设置表格是否允许自定义表头单元格行数。
2.通过 customRowSpan 设置单元格所占行数。

争取能加到你的库中，我不用单独发布了。
Signed-off-by: lijun_ay <lijun_ay@126.com>