### PR TITLE
fix: fix#1858

### DIFF
--- a/packages/table/src/methods.js
+++ b/packages/table/src/methods.js
@@ -2110,7 +2110,7 @@ const Methods = {
                   let colWidth = column.renderWidth
                   if (cellElem) {
                     if (colspan > 1) {
-                      const columnIndex = this.getColumnIndex(column)
+                      const columnIndex = this.getVTColumnIndex(column)
                       for (let index = 1; index < colspan; index++) {
                         const nextColumn = this.getColumns(columnIndex + index)
                         if (nextColumn) {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/49467518/190989962-2194ea11-abbb-4adb-bb12-6ae3ad8f11c9.png)
前两列被隐藏了，通过 `getColumnIndex` 获取到错误的索引，导致宽度计算错误