### PR TITLE
fix: 修复某些场合会一直触发滚动条的问题

### DIFF
--- a/styles/button.scss
+++ b/styles/button.scss
@@ -299,9 +299,11 @@ $btnThemeList: (
 }
 
 .vxe-button--dropdown-panel {
+  z-index: -1;
   display: none;
   position: absolute;
   right: 0;
+  top: 2px;
   padding: 4px 0;
   &.animat--leave {
     display: block;


### PR DESCRIPTION
在某些情况下，会触发body滚动条，导致重新计算位置，反复计算。
![img](https://user-images.githubusercontent.com/4559753/197717522-4c37e570-699b-4caf-9a2c-81644ffd7fda.gif)
