### PR TITLE
fix: 当处于iframe中时, 拖动效果无法清除

### DIFF
--- a/packages/header/src/header.ts
+++ b/packages/header/src/header.ts
@@ -3,6 +3,7 @@ import XEUtils from 'xe-utils'
 import { convertToRows } from './util'
 import { getColMinWidth } from '../../table/src/util'
 import { hasClass, getOffsetPos, addClass, removeClass } from '../../tools/dom'
+import { clearIframeMouseMoveEffect } from '../../tools/utils'
 
 import { VxeTablePrivateMethods, VxeTableConstructor, VxeTableMethods, VxeTableDefines, VxeColumnPropTypes } from '../../../types/all'
 
@@ -107,6 +108,7 @@ export default defineComponent({
       addClass(tableEl, 'drag--resize')
       resizeBarElem.style.display = 'block'
       document.onmousemove = updateEvent
+      clearIframeMouseMoveEffect()
       document.onmouseup = function (evnt) {
         document.onmousemove = domMousemove
         document.onmouseup = domMouseup

--- a/packages/keyboard/src/hook.ts
+++ b/packages/keyboard/src/hook.ts
@@ -1,7 +1,7 @@
 import XEUtils from 'xe-utils'
 import { browse, hasClass, getAbsolutePos, addClass, removeClass, getEventTargetNode } from '../../tools/dom'
-
 import { VxeGlobalHooksHandles, TableKeyboardPrivateMethods } from '../../../types/all'
+import { clearIframeMouseMoveEffect } from '../../tools/utils'
 
 function getTargetOffset (target: any, container: any) {
   let offsetTop = 0
@@ -195,6 +195,7 @@ const tableKeyboardHook: VxeGlobalHooksHandles.HookOptions = {
           }
           handleChecked(evnt)
         }
+        clearIframeMouseMoveEffect()
         document.onmouseup = (evnt) => {
           stopMouseScroll()
           removeClass(el, 'drag--range')

--- a/packages/modal/src/modal.ts
+++ b/packages/modal/src/modal.ts
@@ -2,7 +2,7 @@ import { defineComponent, h, Teleport, ref, Ref, computed, reactive, nextTick, w
 import XEUtils from 'xe-utils'
 import { useSize } from '../../hooks/size'
 import { getDomNode, getEventTargetNode } from '../../tools/dom'
-import { getLastZIndex, nextZIndex, getFuncText } from '../../tools/utils'
+import { getLastZIndex, nextZIndex, getFuncText, clearIframeMouseMoveEffect } from '../../tools/utils'
 import { errLog } from '../../tools/log'
 import { GlobalEvent, hasEventKey, EVENT_KEYS } from '../../tools/event'
 import GlobalConfig from '../../v-x-e-table/src/conf'
@@ -518,6 +518,7 @@ export default defineComponent({
           boxElem.style.top = `${top}px`
           boxElem.className = boxElem.className.replace(/\s?is--drag/, '') + ' is--drag'
         }
+        clearIframeMouseMoveEffect()
         document.onmouseup = () => {
           document.onmousemove = domMousemove
           document.onmouseup = domMouseup
@@ -674,6 +675,7 @@ export default defineComponent({
         }
         modalMethods.dispatchEvent('zoom', params, evnt)
       }
+      clearIframeMouseMoveEffect()
       document.onmouseup = () => {
         reactData.zoomLocat = null
         document.onmousemove = domMousemove

--- a/packages/tools/utils.ts
+++ b/packages/tools/utils.ts
@@ -47,3 +47,16 @@ export function formatText (value: any, placeholder?: any) {
 export function eqEmptyValue (cellValue: any) {
   return cellValue === '' || XEUtils.eqNull(cellValue)
 }
+
+/**
+ * 当处于 iframe 中时, preventDefault 会导致 mouseup 事件无法触发
+ * 此时拖动效果无法清除
+ */
+export function clearIframeMouseMoveEffect () {
+  if (window.self !== window.top) {
+    document.addEventListener('mouseleave', () => {
+      const event = new MouseEvent('mouseup')
+      document.dispatchEvent(event)
+    }, { once: true })
+  }
+}


### PR DESCRIPTION
复现地址: [codesandbox](https://codesandbox.io/s/vxe-table-draggable-4jgdci)

当弹窗拖动超出iframe的区域时, 拖动效果无法取消.

测试发现是preventDefault导致的, 这里仅仅做了下iframe兼容处理. 
如果要修改这个问题, 设计到的改动比较大, 我对项目代码并不熟悉.