### PR TITLE
style: better box-shadow

### DIFF
--- a/styles/variable.scss
+++ b/styles/variable.scss
@@ -97,8 +97,8 @@ $vxe-table-checkbox-range-border-width: 1px !default;
 $vxe-table-checkbox-range-border-color: #006af1 !default;
 $vxe-table-checkbox-range-background-color: rgba(50,128,252,0.2) !default;
 
-$vxe-table-fixed-left-scrolling-box-shadow: 4px 3px 4px 0px rgba(0, 0, 0, 0.12) !default;
-$vxe-table-fixed-right-scrolling-box-shadow: -4px 3px 4px 0px rgba(0, 0, 0, 0.12) !default;
+$vxe-table-fixed-left-scrolling-box-shadow: 8px 0px 10px -5px rgba(0, 0, 0, 0.12) !default;
+$vxe-table-fixed-right-scrolling-box-shadow: -8px 0px 10px -5px rgba(0, 0, 0, 0.12) !default;
 
 /*filter*/
 $vxe-table-filter-panel-background-color: #fff !default;


### PR DESCRIPTION
# 改动前
列固定的时候，浮动的列在下方出现了阴影，导致滚动条看起来有点脏脏的感觉，在自定义滚动条样式的时候更加明显。

![GF_XRJR(QK 6T`N52EO{5)P](https://user-images.githubusercontent.com/33471933/200095189-c7d8bc0d-f837-48fb-aaff-239371ce9349.png)

![U_FJAMYYX1MOZ9HXG~5WJJ0](https://user-images.githubusercontent.com/33471933/200095181-624450cd-c780-47f9-ac9c-ff42c7de5419.png)

# 改动后
这次提交修改了样式，消除了下方多余的box-shadow

![%6ZI_J93(%2R55F9`)XC63O](https://user-images.githubusercontent.com/33471933/200095261-71b90144-e55d-454c-9c8a-3906ff35e883.png)

![JN315FI1 X2WM`}E80NWSI](https://user-images.githubusercontent.com/33471933/200095263-7df3cdc4-d74e-41ce-b324-2c7252890d1c.png)



