### PR TITLE
fix: 当首次加载懒加载树子节点时,多选禁用的子节点也会被勾选上

### DIFF
--- a/packages/table/src/methods.js
+++ b/packages/table/src/methods.js
@@ -3997,9 +3997,9 @@ const Methods = {
             if (childRows.length && treeExpandeds.indexOf(row) === -1) {
               treeExpandeds.push(row)
             }
-            // 如果当前节点已选中，则展开后子节点也被选中
+            // 如果当前节点已选中，则展开后可以允许选择的子节点也被选中
             if (!checkStrictly && this.isCheckedByCheckboxRow(row)) {
-              this.setCheckboxRow(childRows, true)
+              this.setCheckboxRow(row, true)
             }
             return this.$nextTick().then(() => {
               if (transform) {


### PR DESCRIPTION
树状懒加载时，当父节点被勾选且首次加载子节点时，无论子节点勾选是否禁用，都会被勾选上

测试发现是 this.setCheckboxRow(childRows, true)会使 this.eqRow(item, row)在首层判断是默认为true，会忽略掉子节点的是否可勾选判断就直接勾选上。所以改为又父节点开始遍历。解决勾选判断问题