### PR TITLE
feat: wheel模式下按住shift不拦截原生滚动事件

### DIFF
--- a/packages/table/src/body.ts
+++ b/packages/table/src/body.ts
@@ -666,7 +666,8 @@ export default defineComponent({
       const isRollY = scrollTop !== lastScrollTop
 
       // 用于鼠标纵向滚轮处理
-      if (isRollY) {
+      // 如果按住了SHIFT,不拦截原生事件 https://github.com/x-extends/vxe-table/issues/1828
+      if (isRollY && !evnt.shiftKey) {
         evnt.preventDefault()
         tableInternalData.lastScrollTop = scrollTop
         tableInternalData.lastScrollLeft = scrollLeft


### PR DESCRIPTION
chrome支持按住shift键时   鼠标纵向滚动修改为横向滚动
部分用户习惯此逻辑情况下, 虚拟列表开启wheel模式后不支持该功能

代码只需要放开拦截即可,或者提供一个配置项开关  供自由开启