### PR TITLE
fix:分页插件跳转页码数字显示问题修复

### DIFF
--- a/packages/pager/src/pager.js
+++ b/packages/pager/src/pager.js
@@ -373,6 +373,8 @@ export default {
       if (currentPage !== this.currentPage) {
         this.$emit('update:currentPage', currentPage)
         this.$emit('page-change', { type: 'current', pageSize: this.pageSize, currentPage })
+      } else {
+        this.inpCurrPage = currentPage
       }
     },
     pageSizeEvent (pageSize) {


### PR DESCRIPTION
复现步骤：
1.将分页跳转的输入框输入一个超过当前分页总数的值，回车，此时正常显示
2.切换每页条数，此时输入框也显示正常，再将输入框内输入一个超过当前总的分页数的数值，回车，此时正常显示
3.此时切换每页条数的下拉，此时分页跳转输入框内显示的值会出现问题