### PR TITLE
fix: 修复vxe-select的class-name属性没有正确配置的问题

### DIFF
--- a/packages/select/src/select.ts
+++ b/packages/select/src/select.ts
@@ -911,7 +911,7 @@ export default defineComponent({
       const prefixSlot = slots.prefix
       return h('div', {
         ref: refElem,
-        class: ['vxe-select', className ? (XEUtils.isFunction(className) ? className({ $select: $xeselect }) : className) : '', {
+        class: ['vxe-select', {
           [`size--${vSize}`]: vSize,
           'is--visivle': visiblePanel,
           'is--disabled': disabled,
@@ -948,7 +948,7 @@ export default defineComponent({
         }, [
           h('div', {
             ref: refOptionPanel,
-            class: ['vxe-table--ignore-clear vxe-select--panel', {
+            class: ['vxe-table--ignore-clear vxe-select--panel', className ? (XEUtils.isFunction(className) ? className({ $select: $xeselect }) : className) : '', {
               [`size--${vSize}`]: vSize,
               'is--transfer': transfer,
               'animat--leave': !loading && reactData.animatVisible,


### PR DESCRIPTION
根据文档说明【class-name: 给下拉框附加 className】，但是实际实现中，class-name的自定义类名被添加进了select本体中，而不是下拉面板