### PR TITLE
fix(typo): 两次监听props.data触发两次loadTableData方法（issue#1869）

### DIFF
--- a/packages/table/src/table.ts
+++ b/packages/table/src/table.ts
@@ -6004,9 +6004,9 @@ export default defineComponent({
     }
 
     const dataFlag = ref(0)
-    watch(() => props.data ? props.data.length : -1, () => {
-      dataFlag.value++
-    })
+    // watch(() => props.data ? props.data.length : -1, () => {
+    //   dataFlag.value++
+    // })
     watch(() => props.data, () => {
       dataFlag.value++
     })


### PR DESCRIPTION
#1869 #2110 