### PR TITLE
修复虚拟滚动白屏问题

### DIFF
--- a/styles/table.scss
+++ b/styles/table.scss
@@ -454,10 +454,14 @@
   font-family: var(--vxe-font-family);
   direction: ltr;
   .vxe-table--body-wrapper {
-    background-color: var(--vxe-table-body-background-color);
+    table {
+      background-color: var(--vxe-table-body-background-color);
+    }
   }
   .vxe-table--footer-wrapper {
-    background-color: var(--vxe-table-footer-background-color);
+    table {
+      background-color: var(--vxe-table-footer-background-color);
+    }
   }
   .vxe-table--header,
   .vxe-table--body,


### PR DESCRIPTION
项目中使用虚拟滚动，滚动一快就会白屏，我看了源码，再看渲染元素，发现渲染的是很快的，跟得上的，但是还是会出现白屏，后面检查样式，发现只要把这个背景色去掉，滚动一点问题都没有
![I300OI_Z)B$YG3DAS)WB5A](https://github.com/x-extends/vxe-table/assets/57588553/b37d86da-8c49-454f-9de4-16c08989bf21)
直接给table设置背景色也没问题
就是给最外层这个div设置背景色，会出现这样情况，感觉这时的浏览器渲染机制是，先渲染背景色，再渲染表格

个人感觉最有可能是绘制顺序的原因
![GSM}G6%G_(65C53 7_~QK0H](https://github.com/x-extends/vxe-table/assets/57588553/d558ae3c-2e7e-4799-972b-ccbe5cca65d1)
![image](https://github.com/x-extends/vxe-table/assets/57588553/7cadfbe0-e468-4bbf-9b7a-79b08d987228)

