### PR TITLE
fix: package.json添加browserslist字段，转义打包产物中E6语法

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,5 +98,9 @@
   "bugs": {
     "url": "https://github.com/x-extends/vxe-table/issues"
   },
-  "homepage": "https://vxetable.cn/"
+  "homepage": "https://vxetable.cn/",
+  "browserslist": [
+    "> 1%",
+    "last 2 versions"
+  ]
 }


### PR DESCRIPTION
package.json添加browserslist字段，转义打包产物中E6语法，使打包产物index.umd.min.js语法兼容IE11浏览器