### PR TITLE
fix:修复tooltip,menu 在shadowDOM下出现位置偏移问题

### DIFF
--- a/packages/menu/src/hooks.ts
+++ b/packages/menu/src/hooks.ts
@@ -38,8 +38,9 @@ const tableMenuHook: VxeGlobalHooksHandles.HookOptions = {
               evnt.preventDefault()
               $xetable.updateZindex()
               const { scrollTop, scrollLeft, visibleHeight, visibleWidth } = getDomNode()
-              let top = evnt.clientY + scrollTop
-              let left = evnt.clientX + scrollLeft
+              const bodyRect = document.body.getBoundingClientRect()
+              let top = evnt.clientY + scrollTop - bodyRect.top
+              let left = evnt.clientX + scrollLeft - bodyRect.left
               const handleVisible = () => {
                 internalData._currMenuParams = params
                 Object.assign(ctxMenuStore, {

--- a/packages/tools/dom.ts
+++ b/packages/tools/dom.ts
@@ -133,8 +133,9 @@ export function getOffsetPos (elem: any, container: any) {
 
 export function getAbsolutePos (elem: any) {
   const bounding = elem.getBoundingClientRect()
-  const boundingTop = bounding.top
-  const boundingLeft = bounding.left
+  const bodyRect = document.body.getBoundingClientRect()
+  const boundingTop = bounding.top - bodyRect.top
+  const boundingLeft = bounding.left - bodyRect.left
   const { scrollTop, scrollLeft, visibleHeight, visibleWidth } = getDomNode()
   return { boundingTop, top: scrollTop + boundingTop, boundingLeft, left: scrollLeft + boundingLeft, visibleHeight, visibleWidth }
 }


### PR DESCRIPTION
右键菜单和提示在shadowDOM 下渲染会出现位置偏移的情况