### PR TITLE
Update dom.js

### DIFF
--- a/packages/tools/dom.js
+++ b/packages/tools/dom.js
@@ -132,9 +132,11 @@ export const DomTools = {
     return getNodeOffset(elem, container, { left: 0, top: 0 })
   },
   getAbsolutePos (elem) {
+    // 当主页面嵌套在iframe时，elem.getBoundingClientRect()仅计算在当前body内的边界距离，忽略了body所在的边界距离
+    const bodyBounding = document.body.getBoundingClientRect()
     const bounding = elem.getBoundingClientRect()
-    const boundingTop = bounding.top
-    const boundingLeft = bounding.left
+    const boundingTop = bounding.top - bodyBounding.top
+    const boundingLeft = bounding.left - bodyBounding.left
     const { scrollTop, scrollLeft, visibleHeight, visibleWidth } = getDomNode()
     return { boundingTop, top: scrollTop + boundingTop, boundingLeft, left: scrollLeft + boundingLeft, visibleHeight, visibleWidth }
   },


### PR DESCRIPTION
当主页面嵌套在iframe时，elem.getBoundingClientRect()仅计算在当前body内的边界距离，忽略了body所在的边界距离,导致tooltip在微前端嵌套环境时偏离，正常情况下body的边界距离为0，不影响正常使用