### PR TITLE
feat: 重构原来的多行选择功能

### DIFF
--- a/packages/table/src/table.ts
+++ b/packages/table/src/table.ts
@@ -1988,6 +1988,63 @@ export default defineComponent({
       return nextTick()
     }
 
+    const handleCheckedCheckboxRows = (rows: any[], value: boolean) => {
+      const { treeConfig } = props
+      const { checkboxReserveRowMap } = internalData
+      const { selectCheckboxMaps } = reactData
+      const selectRowMaps = { ...selectCheckboxMaps }
+      const checkboxOpts = computeCheckboxOpts.value
+      const { checkField, reserve, checkStrictly } = checkboxOpts
+      if (checkField) {
+        if (treeConfig && !checkStrictly) {
+          // todo
+        } else {
+          rows.forEach((row) => {
+            XEUtils.set(row, checkField, value)
+          })
+        }
+      } else {
+        if (treeConfig && !checkStrictly) {
+          // todo
+        } else {
+          if (value) {
+            rows.forEach((row) => {
+              const rowid = getRowid($xetable, row)
+              if (!selectRowMaps[rowid]) {
+                selectRowMaps[rowid] = row
+              }
+            })
+          } else {
+            rows.forEach((row) => {
+              const rowid = getRowid($xetable, row)
+              if (selectRowMaps[rowid]) {
+                delete selectRowMaps[rowid]
+              }
+            })
+          }
+        }
+      }
+  
+      if (reserve) {
+        if (value) {
+          rows.forEach((row) => {
+            const rowid = getRowid($xetable, row)
+            checkboxReserveRowMap[rowid] = row
+          })
+        } else {
+          rows.forEach((row) => {
+            const rowid = getRowid($xetable, row)
+            if (checkboxReserveRowMap[rowid]) {
+              delete checkboxReserveRowMap[rowid]
+            }
+          })
+        }
+      }
+      reactData.selectCheckboxMaps = selectRowMaps
+      tablePrivateMethods.checkSelectionStatus()
+      return nextTick()
+    }
+
     // 还原展开、选中等相关状态
     const handleReserveStatus = () => {
       const { treeConfig } = props
@@ -3476,6 +3533,14 @@ export default defineComponent({
       setAllCheckboxRow (value) {
         return handleCheckedAllCheckboxRow(value, true)
       },
+      /**
+       * 用于多选行，设置所选行的选中状态，暂不支持树结构
+       * @param {Array} rows 需要设置的行
+       * @param {Boolean} value 是否选中
+       */
+      setCheckboxRows (rows, value) {
+          return handleCheckedCheckboxRows(rows, value);
+      }
       /**
        * 获取单选框保留选中的行
        */


### PR DESCRIPTION
vxe-table自带的setCheckboxRow方法，在大量数据下会有延迟。例如一个表格数据有12列，400行，直接点击全选大概0.5秒，而通过setCheckboxRow全选将大概花费1.5秒。主要原因是setCheckboxRow通过循环调用handleSelectRow,而handleSelectRow每次执行都会判断一次全选按钮状态，这将耗费大量时间。对于多行选择，其实只要最后判断一次全选按钮状态即可。