### PR TITLE
fix: 修复字体图标偶现的乱码问题

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -188,7 +188,10 @@ function toCSSUnicode (css) {
 }
 
 gulp.task('build_lib', () => {
-  const styleStr = fs.readFileSync('lib_temp/index.css', 'utf-8')
+  let styleStr = fs.readFileSync('lib_temp/index.css', 'utf-8')
+  if (!styleStr.startsWith('@charset')) {
+    styleStr = `@charset "UTF-8";\n${styleStr}`
+  }
   fs.writeFileSync('lib_temp/index.css', toCSSUnicode(styleStr))
   return merge(
     gulp.src('es/index.common.js')


### PR DESCRIPTION
修复字体图标在浏览器偶现乱码问题；偶现的乱码主要出现在 浏览器缓存了 CSS 的情况下，刷新页面的时候，在浏览器的调试界面开发者工具中看不到 CSS 文件的加载记录，浏览器会从自己的缓存中读取文件，由于文件没有显式的声明 `UTF-8` 编码，导致浏览器错误地解析了文件的编码，导致乱码的出现。

告诉浏览器使用 `UTF-8` 编码解析 CSS 文件，这在处理包含特殊或非拉丁字符的 CSS 文件时尤其重要。

修复 #1738 #1905 #1912 