### PR TITLE
fix TreeTable 懒加载数据首次新增行时出现重复数据 #2320

### DIFF
--- a/packages/edit/src/hook.ts
+++ b/packages/edit/src/hook.ts
@@ -185,7 +185,10 @@ const editHook: VxeGlobalHooksHandles.HookOptions = {
                   if (isInsertNextRow) {
                     targetIndex = targetIndex + 1
                   }
-                  parentChilds.splice(targetIndex, 0, ...newRecords)
+                  // 在开启懒加载的情况下，首次 insert row 会导致重复添加
+                  if (parentChilds !== parentMapChilds) {
+                    parentChilds.splice(targetIndex, 0, ...newRecords)
+                  }
                 }
               }
             } else {

--- a/packages/edit/src/hook.ts
+++ b/packages/edit/src/hook.ts
@@ -84,7 +84,10 @@ const editHook: VxeGlobalHooksHandles.HookOptions = {
             mapChilds = parentRow[childrenField] = []
           }
           parentChilds[funcName](item)
-          mapChilds[funcName](item)
+          // 在开启懒加载的情况下，首次 insert row 会导致重复添加
+          if (mapChilds !== parentChilds) {
+            mapChilds[funcName](item)
+          }
           const rest = { row: item, rowid, seq: -1, index: -1, _index: -1, $index: -1, items: parentChilds, parent: parentRow, level: parentLevel + 1 }
           fullDataRowIdData[rowid] = rest
           fullAllDataRowIdData[rowid] = rest


### PR DESCRIPTION
新增行时检查 parentChilds 和 parentMapChilds 是否是同一个对象，如果是那么只做一次操作！(这两个对象只在当前新增数据首次 insert row 时才会相同)