### PR TITLE
fix: 数组监听变化不使用deep，则无法监听内部对象变化，新增deep监听之后，用户可以手动处理formItems，期望老板帮忙mer…

### DIFF
--- a/packages/form/src/form.ts
+++ b/packages/form/src/form.ts
@@ -632,6 +632,8 @@ export default defineComponent({
     })
     watch(() => props.items, () => {
       itemFlag.value++
+    }, {
+      deep: true
     })
     watch(itemFlag, () => {
       loadItem(props.items || [])


### PR DESCRIPTION
…ge一下