### PR TITLE
fix:修复 _clearValidate方法中读取不到visible属性问题

### DIFF
--- a/packages/validator/src/mixin.js
+++ b/packages/validator/src/mixin.js
@@ -365,7 +365,7 @@ export default {
       const rowList = XEUtils.isArray(rows) ? rows : (rows ? [rows] : [])
       const colList = (XEUtils.isArray(fieldOrColumn) ? fieldOrColumn : (fieldOrColumn ? [fieldOrColumn] : []).map(column => handleFieldOrColumn(this, column)))
       let validErrMaps = {}
-      if (validTip && validTip.reactData.visible) {
+      if (validTip && validTip.visible) {
         validTip.close()
       }
       // 如果是单个提示模式


### PR DESCRIPTION
v3.7.7 ~v3.7.9 在 validator/src/mixin.js   _clearValidate方法中 
` if (validTip && validTip.reactData.visible) {
        validTip.close()
      }`
validTip对象中没有reactData属性，导致访问不到visible 属性报错