### PR TITLE
fix: 将引用从VxeTablePrivateRef重命名为VxeTableDataRow #2427

### DIFF
--- a/packages/table/src/table.ts
+++ b/packages/table/src/table.ts
@@ -18,7 +18,7 @@ import TableImportPanelComponent from '../module/export/import-panel'
 import TableExportPanelComponent from '../module/export/export-panel'
 import TableMenuPanelComponent from '../module/menu/panel'
 
-import type { VxeGridConstructor, VxeGridPrivateMethods, VxeTableConstructor, TableReactData, TableInternalData, VxeTablePropTypes, VxeToolbarConstructor, TablePrivateMethods, VxeTablePrivateRef, VxeTablePrivateComputed, VxeTablePrivateMethods, TableMethods, VxeTableMethods, VxeTableDefines, VxeTableProps, VxeColumnPropTypes, VxeLoadingComponent, VxeTooltipInstance, VxeTooltipComponent } from '../../../types'
+import type { VxeGridConstructor, VxeGridPrivateMethods, VxeTableConstructor, TableReactData, TableInternalData, VxeTablePropTypes, VxeToolbarConstructor, TablePrivateMethods, VxeTableDataRow, VxeTablePrivateComputed, VxeTablePrivateMethods, TableMethods, VxeTableMethods, VxeTableDefines, VxeTableProps, VxeColumnPropTypes, VxeLoadingComponent, VxeTooltipInstance, VxeTooltipComponent } from '../../../types'
 
 const { getConfig, getI18n, renderer, formats, createEvent, globalResize, interceptor, hooks, globalEvents, GLOBAL_EVENT_KEYS, useFns } = VxeUI
 
@@ -588,7 +588,7 @@ export default defineComponent({
       return false
     })
 
-    const refMaps: VxeTablePrivateRef = {
+    const refMaps: VxeTableDataRow = {
       refElem,
       refTooltip,
       refValidTooltip,


### PR DESCRIPTION
类型名称VxeTablePrivateRef已更改为VxeTableDataRow，但引用未更新，导致未解决的类型错误。此提交更新了对新类型名称VxeTableDataRow的所有引用