### PR TITLE
当column设置为html时，直接获取元素的innerHTML

### DIFF
--- a/packages/table/src/methods.js
+++ b/packages/table/src/methods.js
@@ -3133,7 +3133,7 @@ const Methods = {
     const { showAll, enabled, contentMethod } = tooltipOpts
     const customContent = contentMethod ? contentMethod(params) : null
     const useCustom = contentMethod && !XEUtils.eqNull(customContent)
-    const content = useCustom ? customContent : (column.type === 'html' ? overflowElem.innerText : overflowElem.textContent).trim()
+    const content = useCustom ? customContent : (column.type === 'html' ? overflowElem.innerHTML : overflowElem.textContent).trim()
     const isCellOverflow = overflowElem.scrollWidth > overflowElem.clientWidth
     if (content && (showAll || enabled || useCustom || isCellOverflow)) {
       Object.assign(tooltipStore, {


### PR DESCRIPTION
# 这个还需要配合表格的tooltip-config的useHTML属性一同使用，否则innerHTML会被作为一个文本进行输出。
example:
```vue
<vxe-table
      ...
      :tooltip-config="{useHTML: true, theme: 'light'}">
      ....
</vxe-table>
```