### PR TITLE
fix: env variable name error

### DIFF
--- a/packages/modal/src/modal.ts
+++ b/packages/modal/src/modal.ts
@@ -928,7 +928,7 @@ export default defineComponent({
     })
 
     onMounted(() => {
-      if (process.env.VUE_APP_VXE_ENV === 'development') {
+      if (process.env.VUE_APP_VXE_TABLE_ENV === 'development') {
         if (props.type === 'modal' && props.showFooter && !(props.showConfirmButton || props.showCancelButton || slots.footer)) {
           warnLog('vxe.modal.footPropErr')
         }


### PR DESCRIPTION
`VUE_APP_VXE_ENV` 在 v4.6 版本中并不存在，应该修改为 `VUE_APP_VXE_TABLE_ENV`