### PR TITLE
fix: 自适应列宽，当vxe-cell首个节点为text节点时，宽度获取不当； 应该使用 firstElementChild 来获取宽度；

### DIFF
--- a/packages/table/src/table.ts
+++ b/packages/table/src/table.ts
@@ -1233,7 +1233,7 @@ export default defineComponent({
                   titleWidth += (btnEl as HTMLElement).offsetWidth + 1
                 })
               } else {
-                const labelEl = cellEl.firstChild as HTMLElement
+                const labelEl = cellEl.firstElementChild as HTMLElement
                 if (labelEl) {
                   titleWidth = labelEl.offsetWidth
                 }


### PR DESCRIPTION
实际编辑代码时，表头和单元格的首个元素，用户非常容易写成 注释/vIf: false时渲染的注释 等文本节点； 
fix: 自适应列宽，当vxe-cell首个节点为text节点时，宽度获取不当； 应该使用 firstElementChild 来获取宽度；