### PR TITLE
fix: 解决拖拽结束后，树结构变成了平铺

### DIFF
--- a/packages/table/src/methods.ts
+++ b/packages/table/src/methods.ts
@@ -2423,15 +2423,21 @@ const Methods = {
     const { tableFullData, tableFullTreeData } = internalData
     if (treeConfig) {
       const treeOpts = $xeTable.computeTreeOpts
-      const { transform, mapChildrenField } = treeOpts
+      const { transform, mapChildrenField, rowField, parentField } = treeOpts
       const childrenField = treeOpts.children || treeOpts.childrenField
       if (transform) {
         return XEUtils.toArrayTree(
           XEUtils.toTreeArray(tableFullTreeData, {
+            key: rowField,
+            parentKey: parentField,
             children: mapChildrenField
           }),
-          { children: childrenField }
-        )
+          {
+            key: rowField,
+            parentKey: parentField,
+            children: childrenField,
+            mapChildren: mapChildrenField
+          }
       }
       return tableFullTreeData.slice(0)
     }
@@ -5543,7 +5549,7 @@ const Methods = {
                   // 根到根
                 }
 
-                const fullList = XEUtils.toTreeArray(internalData.afterTreeFullData, { children: childrenField })
+                const fullList = XEUtils.toTreeArray(internalData.afterTreeFullData, { key: rowField, parentKey: parentField, children: childrenField })
 
                 // 移出
                 const otfIndex = $xeTable.findRowIndexOf(fullList, dragRow)


### PR DESCRIPTION
问题描述：
当`treeConfig.rowField`被修改为`id`以外的值，拖拽结束后tree结构变成了平铺，parentId都清空了


原因：
在进行扁平化操作时，`keyField`没传用户配置的值，用了默认的`id`，导致匹配不到`parentId`