### PR TITLE
fix(ui-props):修复autoResize默认值,和table-props保持一致.

### DIFF
--- a/packages/ui/index.ts
+++ b/packages/ui/index.ts
@@ -16,7 +16,7 @@ VxeUI.setConfig({
     showHeader: true,
     animat: true,
     delayHover: 250,
-    autoResize: true,
+    autoResize: false,
     minHeight: 144,
     // keepSource: false,
     // showOverflow: null,


### PR DESCRIPTION
修复autoResize默认值,和table-props保持一致